### PR TITLE
Packaging for Meteor

### DIFF
--- a/css/faces
+++ b/css/faces
@@ -1,0 +1,1 @@
+../example/faces

--- a/package.js
+++ b/package.js
@@ -1,0 +1,44 @@
+Package.describe({
+  name: 'pakastin:deck-of-cards',
+  version: '0.1.4',
+  // Brief, one-line summary of the package.
+  summary: 'HTML5 Deck of Cards',
+  // URL to the Git repository containing the source code for this package.
+  git: 'https://github.com/pakastin/deck-of-cards.git',
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
+  documentation: 'README.md'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom('1.2.1');
+  api.use('ecmascript');
+  api.use('stylus');
+
+  api.addFiles('dist/deck.js', 'client', { bare: true });
+  api.addFiles('css/card.styl', 'client');
+
+  // Add card faces and backs
+  api.addAssets('css/faces/back.png', 'client');
+
+  // 52 deck cards
+  for( var i = 0; i < 4; i++ ) {
+    for( var j = 1; j <= 13; j++ ) {
+      api.addAssets('css/faces/' + i + '_' + j + '.svg', 'client');
+    }
+  }
+
+  // 3 jokers
+  for( var k = 1; k <= 3; k++ ) {
+    api.addAssets('css/faces/4_' + k + '.svg', 'client');
+  }
+
+  api.export(['Deck'], ['client']);
+});
+
+Package.onTest(function(api) {
+  api.use('ecmascript');
+  api.use('tinytest');
+
+  api.use('pakastin:deck-of-cards');
+});


### PR DESCRIPTION
[Meteor](https://www.meteor.com/) is a web framework for building real-time, interactive apps using full-stack Javascript. It's become quite popular lately, and is in the top 10 starred GitHub projects.

I recently started building a Meteor app that involves some cards and happened upon your framework. Part of the appeal of Meteor is quick prototyping with an easy way to pull in code. With some minor changes, your repo can be directly published as a Meteor package, allowing other people to make card games and other fun stuff easily in Meteor apps.

In order to publish this as a Meteor package for this and future releases, you'd just have to [install Meteor](https://www.meteor.com/install), build the files in `dist`, then run `meteor publish` in the base repo folder.

Let me know if you have any other questions or comments.

P.S. To enhance adoption, it would be nice to make an API for the decks and cards, but the source is easy enough to browse for now.
